### PR TITLE
:bug: Remove implicit test dependency on <string>

### DIFF
--- a/reflect
+++ b/reflect
@@ -535,7 +535,7 @@ template<class T> struct ref { T& ref_; };
 template<class T> ref(T&) -> ref<T>;
 
 template<std::size_t N>
-constexpr auto nth_pack_element_impl = []<auto... Ns>(std::index_sequence<Ns...>) -> decltype(auto) {
+inline constexpr auto nth_pack_element_impl = []<auto... Ns>(std::index_sequence<Ns...>) -> decltype(auto) {
   return [](auto_<Ns>&&..., auto&& nth, auto&&...) -> decltype(auto) { return REFLECT_FWD(nth); };
 }(std::make_index_sequence<N>{});
 
@@ -594,19 +594,15 @@ struct fixed_string {
 };
 template<class T, std::size_t Capacity, std::size_t Size = Capacity-1> fixed_string(const T (&str)[Capacity]) -> fixed_string<T, Size>;
 
-namespace detail {
-template<typename>
-struct is_unnamed_record_type : std::false_type {};
-template<typename...Ts>
-struct is_unnamed_record_type<std::pair<Ts...>> : std::true_type {};
-template<typename...Ts>
-struct is_unnamed_record_type<std::tuple<Ts...>> : std::true_type {};
-}
 template<typename T>
-constexpr bool is_unnamed_record_type_v = detail::is_unnamed_record_type<T>::value;
+inline constexpr bool is_unnamed_record_type_v = false;
+template<typename...Ts>
+inline constexpr bool is_unnamed_record_type_v<std::pair<Ts...>> = true;
+template<typename...Ts>
+inline constexpr bool is_unnamed_record_type_v<std::tuple<Ts...>> = true;
 
 template<typename T>
-constexpr bool is_record_like_type_v = std::is_aggregate_v<T> or detail::is_unnamed_record_type<T>::value;
+inline constexpr bool is_record_like_type_v = std::is_aggregate_v<T> or is_unnamed_record_type_v<T>;
 
 namespace detail {
 template<class T, std::size_t Bases = 0u, class... Ts> requires std::is_aggregate_v<T>
@@ -1166,7 +1162,7 @@ static_assert(([] {
     struct two_with_base_member : empty, base { int a; base b; };
     using tuple_with_values = std::tuple<int, int, int>;
     using tuple_with_refs = std::tuple<int const&, int &, int *>;
-    using pair_test = std::pair<float, std::string>;
+    using pair_test = std::pair<float, std::string_view>;
 
     static_assert(0 == size<empty>());
     static_assert(0 == size(empty{}));


### PR DESCRIPTION
Also minor improvements to `inline` value templates for correct link behavior.

https://godbolt.org/z/PWMc8ToYf